### PR TITLE
Remove SAP specific development team from project

### DIFF
--- a/PrimeTime.xcodeproj/project.pbxproj
+++ b/PrimeTime.xcodeproj/project.pbxproj
@@ -409,7 +409,6 @@
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				DEVELOPMENT_TEAM = ZK2MG3TWVQ;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
 					"USE_CONFIG=1",
@@ -430,7 +429,6 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CODE_SIGN_STYLE = Manual;
-				DEVELOPMENT_TEAM = ZK2MG3TWVQ;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
 					"USE_CONFIG=1",


### PR DESCRIPTION
The project references an SAP specific development team. This reference has been removed.